### PR TITLE
Removed default config for protocol because it could not be overwritten

### DIFF
--- a/pkg/configuration/default_configuration.yaml
+++ b/pkg/configuration/default_configuration.yaml
@@ -4,7 +4,7 @@ server:
   gracefulTimeoutMs: 15000
 
 docker:
-  protocol: https://
+  protocol:
   registry:
   port: 0
   username:


### PR DESCRIPTION
Removed default config for protocol because it could not be overwritten. It still stayed at `https://` after I set the `docker.protocol` property to `http://`.

Signed-off-by: Wim de Groot <34519486+degrootwim@users.noreply.github.com>